### PR TITLE
Typo

### DIFF
--- a/app/Http/Controllers/Admin/Auth/RegisterController.php
+++ b/app/Http/Controllers/Admin/Auth/RegisterController.php
@@ -52,7 +52,7 @@ class RegisterController extends Controller
     {
         return Validator::make($data, [
             'name' => 'required|max:255',
-            'email' => 'required|email|max:255|unique:users',
+            'email' => 'required|email|max:255|unique:admins',
             'password' => 'required|min:6|confirmed',
         ]);
     }


### PR DESCRIPTION
Fixed a typo, by which it was always checking the default users table, when registering.